### PR TITLE
Correcting/adding Community Over Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,6 @@ The calendar is automatically updated daily, ensuring you always have the latest
 - [OpenSearchCon India](https://events.linuxfoundation.org/opensearchcon-india/)
   > Date: 3rd - 4th June || Mode: In-person || Location: Bengaluru, India.
 
-- [Community Over Code](https://eu.communityovercode.org/)
-  > Date: 3rd - 5th June || Mode: In-person || Location: Bratislava, Slovakia.
-
 - [PyTorch Day China](https://www.lfasiallc.com/pytorch-day-china/)
   > Date: 7th June || Mode: In-person || Location: Beijing, China.
 
@@ -354,6 +351,9 @@ in Cleveland, Ohio.
 
 - [csv,conf,v9](https://csvconf.com/)
   > Date: 10th - 11th September || Mode: In-person || Location: Bologna, Italy
+
+- [Community Over Code](https://communityovercode.org/)
+  > Date: 11th - 14th September || Mode: In-person || Location: Minneapolis, MN, USA
 
 - [PyCon Australia](https://2025.pycon.org.au/)
   > Date: 12th - 16th September || Mode: In-person || Location: Pullman Melbourne, Australia.


### PR DESCRIPTION
Community Over Code (the Apache Software Foundation conference) was in Bratislava in June in 2024, but will be in Minneapolis in September in 2025. 