### PR TITLE
Add Mautic World Conference

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,9 @@ in Cleveland, Ohio.
 <details open>
  <summary><h2> November :sparkles: </h2></summary>
 
+- [Mautic World Conference](https://2025.mauticon.org)
+   > Date: 3rd-4th November (hybrid), 6-7 November (online) || Mode: Hybrid & Online || Location: London, UK.
+
 - [OpenSSF Community Day Korea](https://events.linuxfoundation.org/openssf-community-day-korea/)
    > Date: 4th November || Mode: In-person || Location: Seoul, South Korea.
 


### PR DESCRIPTION
I've added the Mautic World Conference, I'm not sure if this is the best way to write it though:

- 3-4 November is an in-person conference with live streaming (making it hybrid) and a community contribution day
- 6-7 November is an online-only conference